### PR TITLE
[STEP12] 캐시 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,10 @@ dependencies {
 	// Swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
 
+	// Redis
+	implementation ("org.redisson:redisson-spring-boot-starter:3.45.1")
+	testImplementation("com.redis.testcontainers:testcontainers-redis:1.6.4")
+
     // DB
 	runtimeOnly("com.mysql:mysql-connector-j")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
 
 	// Redis
 	implementation ("org.redisson:redisson-spring-boot-starter:3.45.1")
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	testImplementation("com.redis.testcontainers:testcontainers-redis:1.6.4")
 
     // DB

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ services:
     volumes:
       - ./data/mysql/:/var/lib/mysql
 
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"
+
 networks:
   default:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: redis:latest
     container_name: redis
     ports:
-      - "6379:6379"
+      - "6380:6379"
 
 networks:
   default:

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,114 @@
+## 캐시
+### 캐시란?
+- 자주 사용되거나 반복적으로 사용되는 데이터를 빠르게 접근할 수 있도록 임시로 저장하는 저장소
+- 일반적으로 RAM에 위치하여, Disk나 DB 보다 빠른 응답 속도 제공
+
+### 캐시 사용 이유
+- 성능 향상(Latency 감소): DB나 외부 API 호출 없이 캐시에서 데이터를 즉시 반환함으로써 응답 속도를 줄일 수 있음
+- 트래픽 부하 분산: 동일한 요청에 대해 매번 DB를 조회하는 대신 캐시를 사용하게 되면 DB 부하가 감소됨
+- 비용 절감: DB 리소스를 효율적으로 사용하게 되어 인프라 비용 절감
+- 가용성 향상: DB 장애 시에도 최소한의 서비스 지속 가능
+
+### 캐시의 분류
+- Local Cache: 애플리케이션 내부 메모리에 저장(e.g. Caffeine, Ehcache, ...), 속도는 빠르나 인스턴스간 데이터 공유가 어려움
+- Distributed Cache: 외부에 위치한 공유 캐시 서버 사용(e.g. Redis, Memcached, ...), 다수의 서버 간 캐시 공유 가능
+
+### 캐시 전략
+| 전략 이름                    | 설명                                            |
+|--------------------------|-----------------------------------------------|
+| Read-through             | 항상 캐시에서 데이터를 조회하고, 캐시 미스시 DB 조회 후 캐시에 저장      |
+| Write-through            | DB를 업데이트 할 때 마다 캐시도 함께 업데이트                   |
+| Write-behind(Write-back) | 캐시에 먼저 업데이트 하고, 건수나 특정 시간 간격으로 비동기적으로 DB에 업데이트 |
+| Cache invalidation       | DB 업데이트할 때마다 캐시에서 데이터 삭제                      |
+
+### 캐시 설계 시 고려사항
+- 데이터의 정합성(Consistency): 캐시된 데이터가 실제 DB의 최신 데이터와 얼마나 일치해야 하는가?
+- 변경 빈도(Frequency of Update): 자주 바뀌는 데이터는 캐시에 적합하지 않거나 TTL을 짧게 설정해야 함
+- 접근 패턴(Access Pattern): 같은 키로 반복 접근이 일어나는 경우 캐시 효율 높음
+- Key 설계: 조건 조합이 많아지는 조회(e.g. 필터, 정렬)는 Key explosion 위험 존재
+- Stale 데이터 처리: 캐시 TTL 만료 전 변경된 DB 내용을 어떻게 반영할지 고민해야 함(만료 or 명시적 삭제 or 캐시 무효화)
+
+### 캐시의 한계와 주의점
+- Stale 데이터 리스크: TTL 동안 DB와 불일치한 오래된 데이터가 사용자에게 보여질 수 있음
+- Key Explosion: 필터/페이지 조합이 많은 경우 캐시 키 수가 기하급수적으로 증가할 수 있음
+- 복잡한 무효화 로직: 데이터가 변경될 떄 연관된 캐시를 모두 삭제하거나 갱신하는 것이 어려울 수 있음
+- Failover 시 장애 위험: Redis 등 캐시 서버 장애 시 Fallback이 제대로 안되어 전체 서비스가 느려지거나 오류 발생 가능
+
+---
+## 이커머스 캐시 적용 후보
+| 항목                  | 인기 상품 조회 (`/bestsellers`)                        | 상품 목록 조회 (`/products`)                            |
+|---------------------|-------------------------------------------------------|---------------------------------------------------------|
+| **데이터 변화 빈도**   | 낮음 (1일 단위 갱신)                             | 높음 (상품 추가/수정/삭제, 재고/가격 변화 등)               |
+| **접근 패턴**         | 대부분 동일한 키 (`best`)로 조회                           | 다양한 쿼리 조건 (카테고리, 검색어, 필터 등)                |
+| **핫데이터 여부**     | 명확함 (상위 N개 인기 상품)                                | 조건에 따라 달라짐 (일부 인기 카테고리는 핫할 수 있음)         |
+| **캐시 적합성**       | 매우 적합 (읽기 비중 높고 변경 적음)                       | 조건부 적합 (읽기 비중 높지만 쿼리 다양)                   |
+| **캐시 전략 예시**     | - Redis + TTL 24h<br>- Read-through 캐시                   | - 카테고리별 일부 캐싱 (ex. `hot`, `new`)<br>- 캐시 미스 시 DB 조회 |
+| **키 구성 방식**       | 고정 키 (`best`)                                          | 동적 키 (ex. `products:category=shoes&page=1`)           |
+| **캐시 무효화 전략**  | 스케줄러에 의한 주기적 갱신 (ex. 하루 1회)                    | 실시간 무효화 어려움, 갱신 빈도 낮은 쿼리만 캐싱 추천           |
+| **주의할 점**         | TTL 동안 stale 데이터 가능성 있음                           | 조건별 조합 수 많음 → Redis 메모리 부담 가능성             |
+
+인기 상품 조회와 상품 목록 조회에 캐시 적용을 고려해보았을 때,
+데이터의 변화 빈도가 낮고, 읽기 비중이 높은 `인기 상품 조회`에 대해서는 캐시를 적용하고, 비교적 데이터 변화 비중이 높고 데이터의 양이 많은 `상품 목록 조회`에 대해서는 캐시를 적용하지 않기로 결정  
+
+## 인기 상품 조회에 캐시 적용
+
+인기 상품 조회는 최근 3일 판매량을 기준으로 상위 5개의 상품 정보를 반환
+<br />
+현재 인기 상품은 1시간 마다 판매량을 집계하여 BestSeller 테이블에 적재하고, 인기 상품 조회 요청이 오면 최근 3일치를 집계하여 상위 5개의 상품 반환하도록 구현되어 있음.
+
+
+### 캐시 적용 방법
+1. Read-through 전략을 취하여 유저는 항상 캐시에서 데이터를 읽어옴
+    ```java
+    @Cacheable(value = "bestSellers", key = "'best'", cacheManager = "redisCacheManager")
+    public BestSellerDto getBestSellers() {
+    List<BestSeller> bestSellers = bestSellerRepository.getBestSellers();
+    return BestSellerDto.of(bestSellers);
+    }
+    ```
+2. 스케줄러를 이용해 매일 23:50에 인기 상품 데이터 갱신(스케줄러 주기는 24시간)
+    ```java
+    @Scheduled(cron = "0 50 23 * * *")
+    public void preloadBestSellersCache() {
+        BestSellerService proxy = applicationContext.getBean(BestSellerService.class);
+        proxy.refreshBestSellers();
+        log.info("[BestSellerScheduler] 3일간 인기 상품 캐싱 완료");
+    }
+   ```
+   ```java
+   @CachePut(value = "bestSellers", key = "'best'", cacheManager = "redisCacheManager")
+    public BestSellerDto refreshBestSellers() {
+        List<BestSeller> bestSellers = bestSellerRepository.getBestSellers();
+        return BestSellerDto.of(bestSellers);
+    }
+   ```
+3. 이 때 캐시의 TTL은 25시간으로 설정하여 새로운 인기 상품 데이터가 캐시에 적재되는 시간에도 기존에 캐시된 데이터는 유효하므로 유저는 캐시에서 데이터를 조회할 수 있음.
+    ```java
+   @Bean
+    @Primary
+    public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(connectionFactory);
+
+        RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofHours(25));
+        builder.cacheDefaults(configuration);
+        return builder.build();
+    }
+   ```
+
+### 성능 비교
+100명의 사용자가 30초 동안 인기 상품 조회 요청
+- 캐시 적용 전
+<img width="1284" alt="Image" src="https://github.com/user-attachments/assets/fd2ce8eb-28f6-4bf0-9549-7871d02574f4" />
+    - TPS: 254req/sec
+
+- 캐시 적용 후
+<img width="1257" alt="Image" src="https://github.com/user-attachments/assets/c82138f0-3fdd-4af6-9d13-a33cb2237bf4" />
+    - TPS: 13437req/sec
+
+### 결론
+> 캐시 적용 전 `TPS 254req/sec`에서 캐시 적용 후 `TPS 13437req/sec`로 캐시 적용을 통해 **약 53배** 성능 향상됨
+

--- a/src/main/java/kr/hhplus/be/server/application/bestseller/BestSellerFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/bestseller/BestSellerFacade.java
@@ -1,12 +1,10 @@
 package kr.hhplus.be.server.application.bestseller;
 
 import kr.hhplus.be.server.application.bestseller.dto.BestSellerGetResult;
-import kr.hhplus.be.server.domain.bestseller.BestSeller;
 import kr.hhplus.be.server.domain.bestseller.BestSellerService;
+import kr.hhplus.be.server.domain.bestseller.dto.BestSellerDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Component
@@ -15,7 +13,7 @@ public class BestSellerFacade {
     private final BestSellerService bestSellerService;
 
     public BestSellerGetResult getBestSellers() {
-        List<BestSeller> bestSellers = bestSellerService.getBestSellers();
-        return BestSellerGetResult.from(bestSellers);
+        BestSellerDto dto = bestSellerService.getBestSellers();
+        return BestSellerGetResult.from(dto);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/application/bestseller/BestSellerScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/application/bestseller/BestSellerScheduler.java
@@ -67,7 +67,7 @@ public class BestSellerScheduler {
     @Scheduled(cron = "0 50 23 * * *")
     public void preloadBestSellersCache() {
         BestSellerService proxy = applicationContext.getBean(BestSellerService.class);
-        proxy.getBestSellers();
+        proxy.refreshBestSellers();
         log.info("[BestSellerScheduler] 3일간 인기 상품 캐싱 완료");
     }
 }

--- a/src/main/java/kr/hhplus/be/server/application/bestseller/BestSellerScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/application/bestseller/BestSellerScheduler.java
@@ -9,6 +9,7 @@ import kr.hhplus.be.server.domain.product.Product;
 import kr.hhplus.be.server.domain.product.ProductService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ public class BestSellerScheduler {
     private final OrderService orderService;
     private final ProductService productService;
     private final BestSellerService bestSellerService;
+    private final ApplicationContext applicationContext;
 
     @Scheduled(cron = "0 0 * * * *")
     @Transactional
@@ -57,8 +59,15 @@ public class BestSellerScheduler {
     @Scheduled(cron = "0 5 0 * * *")
     @Transactional
     public void deleteOldBestSellers() {
-        LocalDateTime threshold = LocalDateTime.now().minusDays(3);
+        LocalDateTime threshold = LocalDateTime.now().minusDays(2);
         bestSellerService.deleteByCreatedAtBefore(threshold);
         log.info("[BestSellerScheduler] 3일 지난 인기 상품 데이터 삭제 스케줄러 실행 완료");
+    }
+
+    @Scheduled(cron = "0 50 23 * * *")
+    public void preloadBestSellersCache() {
+        BestSellerService proxy = applicationContext.getBean(BestSellerService.class);
+        proxy.getBestSellers();
+        log.info("[BestSellerScheduler] 3일간 인기 상품 캐싱 완료");
     }
 }

--- a/src/main/java/kr/hhplus/be/server/application/bestseller/dto/BestSellerGetResult.java
+++ b/src/main/java/kr/hhplus/be/server/application/bestseller/dto/BestSellerGetResult.java
@@ -1,9 +1,11 @@
 package kr.hhplus.be.server.application.bestseller.dto;
 
 import kr.hhplus.be.server.domain.bestseller.BestSeller;
+import kr.hhplus.be.server.domain.bestseller.dto.BestSellerDto;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class BestSellerGetResult {
@@ -14,7 +16,7 @@ public class BestSellerGetResult {
         this.bestSellers = bestSellers;
     }
 
-    public static BestSellerGetResult from(List<BestSeller> bestSellers) {
-        return new BestSellerGetResult(bestSellers);
+    public static BestSellerGetResult from(BestSellerDto bestSeller) {
+        return new BestSellerGetResult(bestSeller.getBestSellers());
     }
 }

--- a/src/main/java/kr/hhplus/be/server/common/exception/ErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/common/exception/ErrorCode.java
@@ -37,7 +37,9 @@ public enum ErrorCode {
 
     INVALID_DATE_TIME("INVALID_DATE_TIME", 400, "유효하지 않은 날짜입니다."),
 
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", 500, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", 500, "서버 내부 오류입니다."),
+    LOCK_INTERRUPTED("LOCK_INTERRUPTED", 500, "락 인터럽트가 발생하였습니다."),
+    LOCK_NOT_AVAILABLE("LOCK_NOT_AVAILABLE", 500, "락을 획득할 수 없습니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/kr/hhplus/be/server/config/redis/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/redis/RedisConfig.java
@@ -6,9 +6,13 @@ import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-public class RedissonConfig {
+public class RedisConfig {
 
     private static final String REDISSON_HOST_PREFIX = "redis://";
 
@@ -25,5 +29,19 @@ public class RedissonConfig {
         config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
         redissonClient = Redisson.create(config);
         return redissonClient;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
     }
 }

--- a/src/main/java/kr/hhplus/be/server/config/redis/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/redis/RedisConfig.java
@@ -4,13 +4,23 @@ import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+
+@EnableCaching
 @Configuration
 public class RedisConfig {
 
@@ -37,11 +47,26 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(connectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
+
+    @Bean
+    @Primary
+    public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(connectionFactory);
+
+        RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofHours(25));
+        builder.cacheDefaults(configuration);
+        return builder.build();
+    }
+
 }

--- a/src/main/java/kr/hhplus/be/server/config/redis/RedissonConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/redis/RedissonConfig.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        RedissonClient redissonClient = null;
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        redissonClient = Redisson.create(config);
+        return redissonClient;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSeller.java
+++ b/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSeller.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.domain.bestseller;
 
 import jakarta.persistence.*;
 import kr.hhplus.be.server.domain.BaseEntity;
+import kr.hhplus.be.server.domain.bestseller.dto.BestSellerDto;
 import kr.hhplus.be.server.domain.bestseller.dto.BestSellerSummaryResponse;
 import kr.hhplus.be.server.domain.product.Product;
 import lombok.AccessLevel;

--- a/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSellerService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSellerService.java
@@ -2,7 +2,6 @@ package kr.hhplus.be.server.domain.bestseller;
 
 import kr.hhplus.be.server.domain.bestseller.dto.BestSellerDto;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
@@ -20,7 +18,6 @@ public class BestSellerService {
 
     @Cacheable(value = "bestSellers", key = "'best'", cacheManager = "redisCacheManager")
     public BestSellerDto getBestSellers() {
-        log.info("🔥🔥🔥 캐시 없이 DB에서 인기 상품 조회 실행");
         List<BestSeller> bestSellers = bestSellerRepository.getBestSellers();
         return BestSellerDto.of(bestSellers);
     }

--- a/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSellerService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSellerService.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.domain.bestseller;
 
 import kr.hhplus.be.server.domain.bestseller.dto.BestSellerDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,12 @@ public class BestSellerService {
 
     @Cacheable(value = "bestSellers", key = "'best'", cacheManager = "redisCacheManager")
     public BestSellerDto getBestSellers() {
+        List<BestSeller> bestSellers = bestSellerRepository.getBestSellers();
+        return BestSellerDto.of(bestSellers);
+    }
+
+    @CachePut(value = "bestSellers", key = "'best'", cacheManager = "redisCacheManager")
+    public BestSellerDto refreshBestSellers() {
         List<BestSeller> bestSellers = bestSellerRepository.getBestSellers();
         return BestSellerDto.of(bestSellers);
     }

--- a/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSellerService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSellerService.java
@@ -1,12 +1,16 @@
 package kr.hhplus.be.server.domain.bestseller;
 
+import kr.hhplus.be.server.domain.bestseller.dto.BestSellerDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
@@ -14,8 +18,11 @@ public class BestSellerService {
 
     private final BestSellerRepository bestSellerRepository;
 
-    public List<BestSeller> getBestSellers() {
-        return bestSellerRepository.getBestSellers();
+    @Cacheable(value = "bestSellers", key = "'best'", cacheManager = "redisCacheManager")
+    public BestSellerDto getBestSellers() {
+        log.info("🔥🔥🔥 캐시 없이 DB에서 인기 상품 조회 실행");
+        List<BestSeller> bestSellers = bestSellerRepository.getBestSellers();
+        return BestSellerDto.of(bestSellers);
     }
 
     public void save(BestSeller bestSeller) {

--- a/src/main/java/kr/hhplus/be/server/domain/bestseller/dto/BestSellerDto.java
+++ b/src/main/java/kr/hhplus/be/server/domain/bestseller/dto/BestSellerDto.java
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.domain.bestseller.dto;
+
+import kr.hhplus.be.server.domain.bestseller.BestSeller;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BestSellerDto {
+
+    private List<BestSeller> bestSellers;
+
+    private BestSellerDto(List<BestSeller> bestSellers) {
+        this.bestSellers = bestSellers;
+    }
+
+    public static BestSellerDto of(List<BestSeller> bestSellers) {
+        return new BestSellerDto(bestSellers);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
@@ -1,7 +1,7 @@
 package kr.hhplus.be.server.domain.coupon;
 
 import kr.hhplus.be.server.common.exception.ApiException;
-import kr.hhplus.be.server.support.aop.lock.DistributedLock;
+import kr.hhplus.be.server.support.aop.lock.RedissonLock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +21,7 @@ public class CouponService {
     private final CouponRepository couponRepository;
     private final UserCouponRepository userCouponRepository;
 
-    @DistributedLock(key = "'coupon:' + #couponId")
+    @RedissonLock(key = "'coupon:' + #couponId")
     @Transactional
     public void issueCoupon(Long userId, Long couponId) {
         Coupon coupon = couponRepository.findByIdWithLock(couponId)

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -24,9 +23,7 @@ public class CouponService {
 
     @DistributedLock(
             key = "'coupon:' + #couponId",
-            timeUnit = TimeUnit.MILLISECONDS,
-            waitTime = 300,
-            leaseTime = 3000
+            leaseTime = 2
     )
     @Transactional
     public void issueCoupon(Long userId, Long couponId) {

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
@@ -21,10 +21,7 @@ public class CouponService {
     private final CouponRepository couponRepository;
     private final UserCouponRepository userCouponRepository;
 
-    @DistributedLock(
-            key = "'coupon:' + #couponId",
-            leaseTime = 2
-    )
+    @DistributedLock(key = "'coupon:' + #couponId")
     @Transactional
     public void issueCoupon(Long userId, Long couponId) {
         Coupon coupon = couponRepository.findByIdWithLock(couponId)

--- a/src/main/java/kr/hhplus/be/server/domain/point/Point.java
+++ b/src/main/java/kr/hhplus/be/server/domain/point/Point.java
@@ -29,7 +29,6 @@ public class Point extends BaseEntity {
     private Point(Long userId, Long balance) {
         this.userId = userId;
         this.balance = balance;
-        this.version = 0L;
     }
 
     public static Point of(Long userId, Long balance) {

--- a/src/main/java/kr/hhplus/be/server/domain/point/PointHistory.java
+++ b/src/main/java/kr/hhplus/be/server/domain/point/PointHistory.java
@@ -25,14 +25,14 @@ public class PointHistory extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private TransactionType type;
 
-    public PointHistory(Long pointId, Long amount, Long balance, TransactionType type) {
+    private PointHistory(Long pointId, Long amount, Long balance, TransactionType type) {
         this.pointId = pointId;
         this.amount = amount;
         this.balance = balance;
         this.type = type;
     }
 
-    public static PointHistory saveHistory(Point point, Long amount, TransactionType type) {
+    public static PointHistory of(Point point, Long amount, TransactionType type) {
         return new PointHistory(point.getId(), amount, point.getBalance(), type);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/point/PointService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/point/PointService.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.domain.point;
 
 import kr.hhplus.be.server.common.exception.ApiException;
+import kr.hhplus.be.server.support.aop.lock.LettuceLock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ public class PointService {
 
     private final PointRepository pointRepository;
 
+    @LettuceLock(key = "'user:' + #userId")
     @Transactional
     public Point chargePoint(Long userId, Long amount) {
         Point point = pointRepository.findPointByUserIdWithLock(userId)
@@ -41,6 +43,7 @@ public class PointService {
                 .orElseGet(() -> Point.of(userId, 0L));
     }
 
+    @LettuceLock(key = "'user:' + #userId")
     @Transactional
     public Point usePoint(Long userId, Long amount) {
         Point point = pointRepository.findPointByUserIdWithLock(userId)

--- a/src/main/java/kr/hhplus/be/server/support/aop/CustomSpringELParser.java
+++ b/src/main/java/kr/hhplus/be/server/support/aop/CustomSpringELParser.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.support.aop;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+
+    private CustomSpringELParser() {
+    }
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/support/aop/lock/DistributedLock.java
+++ b/src/main/java/kr/hhplus/be/server/support/aop/lock/DistributedLock.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.support.aop.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    String key();
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    long waitTime() default 5L;
+
+    long leaseTime() default 8L;
+}

--- a/src/main/java/kr/hhplus/be/server/support/aop/lock/DistributedLock.java
+++ b/src/main/java/kr/hhplus/be/server/support/aop/lock/DistributedLock.java
@@ -16,5 +16,5 @@ public @interface DistributedLock {
 
     long waitTime() default 5L;
 
-    long leaseTime() default 8L;
+    long leaseTime() default 3L;
 }

--- a/src/main/java/kr/hhplus/be/server/support/aop/lock/DistributedLockAop.java
+++ b/src/main/java/kr/hhplus/be/server/support/aop/lock/DistributedLockAop.java
@@ -1,0 +1,65 @@
+package kr.hhplus.be.server.support.aop.lock;
+
+import kr.hhplus.be.server.common.exception.ApiException;
+import kr.hhplus.be.server.support.aop.CustomSpringELParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+import static kr.hhplus.be.server.common.exception.ErrorCode.LOCK_INTERRUPTED;
+import static kr.hhplus.be.server.common.exception.ErrorCode.LOCK_NOT_AVAILABLE;
+
+@Slf4j
+@Aspect
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RequiredArgsConstructor
+public class DistributedLockAop {
+
+    private static final String REDISSON_LOCK_KEY_PREFIX = "Lock:";
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(kr.hhplus.be.server.support.aop.lock.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_KEY_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            if (!available) {
+                log.info("Lock 획득 실패: {}", key);
+                throw new ApiException(LOCK_NOT_AVAILABLE);
+            }
+
+            log.info("Lock 획득 성공: {}", key);
+            return joinPoint.proceed();
+        } catch (InterruptedException e) {
+            log.error("Lock 대기 중 인터럽트 발생: {}", key, e);
+            Thread.currentThread().interrupt();
+            throw new ApiException(LOCK_INTERRUPTED);
+        } finally {
+            try {
+                rLock.unlock();
+                log.info("Lock 해제: {}", key);
+            } catch (IllegalMonitorStateException e) {
+                log.info("Redisson Lock이 이미 해제되었습니다.");
+            }
+        }
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/support/aop/lock/LettuceLock.java
+++ b/src/main/java/kr/hhplus/be/server/support/aop/lock/LettuceLock.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.support.aop.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LettuceLock {
+
+    String key();
+
+    long timeout() default 3L;
+
+}

--- a/src/main/java/kr/hhplus/be/server/support/aop/lock/LettuceLockAop.java
+++ b/src/main/java/kr/hhplus/be/server/support/aop/lock/LettuceLockAop.java
@@ -1,0 +1,51 @@
+package kr.hhplus.be.server.support.aop.lock;
+
+import kr.hhplus.be.server.support.aop.CustomSpringELParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+@Slf4j
+@Aspect
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RequiredArgsConstructor
+public class LettuceLockAop {
+
+    private static final String LETTUCE_LOCK_KEY_PREFIX = "Lock:";
+
+    private final LettuceLockManager lockManager;
+
+    @Around("@annotation(kr.hhplus.be.server.support.aop.lock.LettuceLock)")
+    public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        LettuceLock lettuceLock = method.getAnnotation(LettuceLock.class);
+
+        String key = LETTUCE_LOCK_KEY_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), lettuceLock.key());
+        String value = UUID.randomUUID().toString();
+        long timeout = lettuceLock.timeout();
+
+        while (!lockManager.tryLock(key, value, timeout)) {
+            log.info("Lock 획득 실패: {}", key);
+            Thread.sleep(100);
+        }
+
+        try {
+            log.info("Lock 획득 성공: {}", key);
+            return joinPoint.proceed();
+        } finally {
+            lockManager.unlock(key, value);
+            log.info("Lock 해제: {}", key);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/support/aop/lock/LettuceLockManager.java
+++ b/src/main/java/kr/hhplus/be/server/support/aop/lock/LettuceLockManager.java
@@ -1,0 +1,40 @@
+package kr.hhplus.be.server.support.aop.lock;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class LettuceLockManager {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public boolean tryLock(String key, String value, long timeoutMs) {
+        return redisTemplate
+                .opsForValue()
+                .setIfAbsent(key, value, Duration.ofSeconds(timeoutMs));
+    }
+
+    public void unlock(String key, String value) {
+        String lua = """
+            if redis.call("get", KEYS[1]) == ARGV[1]
+            then
+                return redis.call("del", KEYS[1])
+            else
+                return 0
+            end
+        """;
+
+        redisTemplate.execute(
+                new DefaultRedisScript<>(lua, Long.class),
+                Collections.singletonList(key),
+                value
+        );
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/support/aop/lock/RedissonLock.java
+++ b/src/main/java/kr/hhplus/be/server/support/aop/lock/RedissonLock.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface DistributedLock {
+public @interface RedissonLock {
 
     String key();
 

--- a/src/main/java/kr/hhplus/be/server/support/aop/lock/RedissonLockAop.java
+++ b/src/main/java/kr/hhplus/be/server/support/aop/lock/RedissonLockAop.java
@@ -24,23 +24,23 @@ import static kr.hhplus.be.server.common.exception.ErrorCode.LOCK_NOT_AVAILABLE;
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
-public class DistributedLockAop {
+public class RedissonLockAop {
 
     private static final String REDISSON_LOCK_KEY_PREFIX = "Lock:";
 
     private final RedissonClient redissonClient;
 
-    @Around("@annotation(kr.hhplus.be.server.support.aop.lock.DistributedLock)")
+    @Around("@annotation(kr.hhplus.be.server.support.aop.lock.RedissonLock)")
     public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
-        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+        RedissonLock redissonLock = method.getAnnotation(RedissonLock.class);
 
-        String key = REDISSON_LOCK_KEY_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        String key = REDISSON_LOCK_KEY_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), redissonLock.key());
         RLock rLock = redissonClient.getLock(key);
 
         try {
-            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            boolean available = rLock.tryLock(redissonLock.waitTime(), redissonLock.leaseTime(), redissonLock.timeUnit());
             if (!available) {
                 log.info("Lock 획득 실패: {}", key);
                 throw new ApiException(LOCK_NOT_AVAILABLE);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,12 @@ spring:
     url: jdbc:mysql://localhost:3307/hhplus?characterEncoding=UTF-8&serverTimezone=UTC&rewriteBatchedStatements=true
     username: application
     password: application
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   jpa:
     show-sql: true
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,7 +39,7 @@ spring:
   data:
     redis:
       host: localhost
-      port: 6379
+      port: 6380
 
   jpa:
     show-sql: true

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server;
 
 import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -9,6 +10,9 @@ import org.testcontainers.utility.DockerImageName;
 class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
+	public static final GenericContainer<?> REDIS_CONTAINER;
+
+	private static final int REDIS_PORT = 6379;
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -20,6 +24,22 @@ class TestcontainersConfiguration {
 		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+
+		REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("redis:latest"))
+				.withExposedPorts(REDIS_PORT);
+		REDIS_CONTAINER.start();
+
+		String redisHost = REDIS_CONTAINER.getHost();
+
+		System.setProperty("spring.data.redis.host", redisHost);
+		System.setProperty("spring.data.redis.port", String.valueOf(REDIS_PORT));
+		System.setProperty("spring.redis.redisson.config",
+				String.format("singleServerConfig:\n" +
+						"  address: \"redis://%s:%d\"\n" +
+						"  connectionMinimumIdleSize: 1\n" +
+						"  connectionPoolSize: 10\n" +
+						"  connectTimeout: 10000\n" +
+						"  timeout: 3000", redisHost, REDIS_PORT));
 	}
 
 	@PreDestroy

--- a/src/test/java/kr/hhplus/be/server/application/bestseller/BestSellerSchedulerTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/bestseller/BestSellerSchedulerTest.java
@@ -92,11 +92,11 @@ class BestSellerSchedulerTest {
         verify(productService, times(1)).getProductWithLock(2L);
     }
 
-    @DisplayName("3일이 지난 데이터를 매일 새벽 00:05")
+    @DisplayName("3일이 지난 데이터를 매일 새벽 00:05에 삭제한다.")
     @Test
     void deleteOldBestSellers() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime expectedThreshold = now.minusDays(3);
+        LocalDateTime expectedThreshold = now.minusDays(2);
 
         // when
         bestSellerScheduler.deleteOldBestSellers();

--- a/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeIntegrationTest.java
@@ -44,12 +44,15 @@ class OrderFacadeIntegrationTest extends IntegrationTestSupport {
     @Test
     void order() {
         User user = userRepository.save(User.of());
+        LocalDate startDate = LocalDate.of(2025, 4, 1);
+        LocalDate endDate = startDate.plusYears(1);
+
         Coupon coupon = couponRepository.save(Coupon.of(
                 "coupon1",
                 1000L,
                 DiscountType.AMOUNT,
-                LocalDate.of(2025, 4, 1),
-                LocalDate.of(2025, 4, 30),
+                startDate,
+                endDate,
                 100L)
         );
         UserCoupon userCoupon = userCouponRepository.save(UserCoupon.of(user, coupon));

--- a/src/test/java/kr/hhplus/be/server/application/payment/PaymentFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/payment/PaymentFacadeIntegrationTest.java
@@ -57,12 +57,15 @@ class PaymentFacadeIntegrationTest extends IntegrationTestSupport {
         long initialBalance = 20000L;
         User user = userRepository.save(User.of());
         Point point = pointRepository.savePoint(Point.of(user.getId(), initialBalance));
+
+        LocalDate startDate = LocalDate.of(2025, 4, 1);
+        LocalDate endDate = startDate.plusYears(1);
         Coupon coupon = couponRepository.save(Coupon.of(
                 "coupon1",
                 1000L,
                 DiscountType.AMOUNT,
-                LocalDate.of(2025, 4, 1),
-                LocalDate.of(2025, 4, 30),
+                startDate,
+                endDate,
                 100L)
         );
         UserCoupon userCoupon = userCouponRepository.save(UserCoupon.of(user, coupon));

--- a/src/test/java/kr/hhplus/be/server/domain/order/OrderServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/order/OrderServiceIntegrationTest.java
@@ -79,12 +79,14 @@ class OrderServiceIntegrationTest extends IntegrationTestSupport {
         long quantity = 10L;
         orderService.addProduct(order, product, quantity);
 
+        LocalDate startDate = LocalDate.of(2025, 4, 1);
+        LocalDate endDate = startDate.plusYears(1);
         Coupon coupon = couponRepository.save(Coupon.of(
                 "coupon1",
                 1000L,
                 DiscountType.AMOUNT,
-                LocalDate.of(2025, 4, 1),
-                LocalDate.of(2025, 4, 30),
+                startDate,
+                endDate,
                 100L)
         );
         UserCoupon userCoupon = userCouponRepository.save(UserCoupon.of(user, coupon));

--- a/src/test/java/kr/hhplus/be/server/domain/point/PointServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/point/PointServiceTest.java
@@ -44,9 +44,9 @@ class PointServiceTest {
                 .create();
 
         given(pointRepository.findPointByUserIdWithLock(userId)).willReturn(Optional.empty());
-        given(pointRepository.savePoint(any(Point.class))).willReturn(point);
-        given(pointRepository.existsByPointIdAndAmountAndTypeAndCreatedAtAfter(eq(2L), eq(chargeAmount), eq(CHARGE), any(LocalDateTime.class)))
+        given(pointRepository.existsByPointIdAndAmountAndTypeAndCreatedAtAfter(eq(null), eq(chargeAmount), eq(CHARGE), any(LocalDateTime.class)))
                 .willReturn(false);
+        given(pointRepository.savePoint(any(Point.class))).willReturn(point);
 
         Point chargePoint = pointService.chargePoint(userId, chargeAmount);
 
@@ -56,7 +56,7 @@ class PointServiceTest {
         verify(pointRepository, times(1)).findPointByUserIdWithLock(userId);
         verify(pointRepository, times(1)).savePoint(any(Point.class));
         verify(pointRepository, times(1))
-                .existsByPointIdAndAmountAndTypeAndCreatedAtAfter(eq(2L), eq(chargeAmount), eq(CHARGE), any(LocalDateTime.class));
+                .existsByPointIdAndAmountAndTypeAndCreatedAtAfter(eq(null), eq(chargeAmount), eq(CHARGE), any(LocalDateTime.class));
     }
 
     @DisplayName("포인트 충전이 처음이 아닌 경우 포인트가 기존에 보유 중인 포인트에 누적이 된다.")

--- a/src/test/java/kr/hhplus/be/server/interfaces/api/bestseller/BestSellerControllerIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/api/bestseller/BestSellerControllerIntegrationTest.java
@@ -3,6 +3,7 @@ package kr.hhplus.be.server.interfaces.api.bestseller;
 import kr.hhplus.be.server.application.bestseller.BestSellerFacade;
 import kr.hhplus.be.server.application.bestseller.dto.BestSellerGetResult;
 import kr.hhplus.be.server.domain.bestseller.BestSeller;
+import kr.hhplus.be.server.domain.bestseller.dto.BestSellerDto;
 import kr.hhplus.be.server.domain.product.Product;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.DisplayName;
@@ -55,7 +56,7 @@ class BestSellerControllerIntegrationTest {
                 BestSeller.of(product5, 100L)
         );
 
-        BestSellerGetResult result = BestSellerGetResult.from(bestSellers);
+        BestSellerGetResult result = BestSellerGetResult.from(BestSellerDto.of(bestSellers));
         given(bestSellerFacade.getBestSellers()).willReturn(result);
 
         mockMvc.perform(get("/api/v1/bestsellers"))

--- a/src/test/java/kr/hhplus/be/server/support/aop/lock/LettuceLockAopTest.java
+++ b/src/test/java/kr/hhplus/be/server/support/aop/lock/LettuceLockAopTest.java
@@ -1,0 +1,66 @@
+package kr.hhplus.be.server.support.aop.lock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class LettuceLockAopTest {
+
+    @Autowired
+    private TestService testService;
+
+    @DisplayName("Lettuce 락 획득 요청이 동시에 100개 발생하면 모든 요청은 성공한다.")
+    @Test
+    void getLettuceLock_concurrently() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    String result = testService.testMethod(1L);
+                    if (result.equals("success")) {
+                        successCount.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        public TestService testService() {
+            return new TestService();
+        }
+    }
+
+    static class TestService {
+
+        @LettuceLock(key = "'test:' + #id")
+        public String testMethod(Long id) {
+            return "success";
+        }
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/support/aop/lock/RedissonLockAopTest.java
+++ b/src/test/java/kr/hhplus/be/server/support/aop/lock/RedissonLockAopTest.java
@@ -1,0 +1,66 @@
+package kr.hhplus.be.server.support.aop.lock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RedissonLockAopTest {
+
+    @Autowired
+    private TestService testService;
+
+    @DisplayName("Redisson 락 획득 요청이 동시에 100개 발생하면 모든 요청은 성공한다.")
+    @Test
+    void getLettuceLock_concurrently() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    String result = testService.testMethod(1L);
+                    if (result.equals("success")) {
+                        successCount.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        public TestService testService() {
+            return new TestService();
+        }
+    }
+
+    static class TestService {
+
+        @RedissonLock(key = "'test:' + #id")
+        public String testMethod(Long id) {
+            return "success";
+        }
+    }
+}


### PR DESCRIPTION
## PR 설명
캐시에 대해 학습한 뒤, 이커머스 시나리오에서 캐시 적용이 필요한 기능을 추리고 분석하여 레디스 캐시 적용을 하였습니다.
인기 상품 조회 기능에 대해 캐시 적용 전/후 성능을 비교하고, 보고서를 작성하였습니다.

## 리뷰 포인트
- 인기 상품 조회에 캐시 적용: 82126e1, 25134b5
- 캐시 보고서 작성: 047d05c

### ⁉️ 리뷰 포인트
- 멘토링 해주신 것을 바탕으로 3일치 인기 상품을 TTL 25시간으로 매일 스케줄러를 돌면서 캐싱해두어 유저는 항상 캐시에서 인기 상품을 조회할 수 있도록 하였습니다. 그 과정에서 유저가 조회하는 서비스 메서드에 @Cacheable을 붙이고, 유저 조회 서비스 메서드와 똑같은 메서드를 만들고 @CachePut 붙여 스케줄러가 캐시 내용을 바꾸는 중에도 캐시 미스가 발생하지 않도록 하였습니다. 이런 방식으로 구현하니 코드 중복이 발생해서 좋지 않은 것 같은데 코치님의 방식이 궁금합니다!

## Definition of Done (DoD)
- [x] 인기 상품 조회에 캐시 적용
- [x] 캐시 보고서 작성